### PR TITLE
Add a wrapper setup for `ethereumjs` client

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ docker run --pull always -v $(pwd)/jwtsecret:/execution-auth.jwt:ro -v $(pwd)/el
 docker run --pull always -v $(pwd)/jwtsecret:/execution-auth.jwt:ro -v $(pwd)/el:/data -p 30303:30303 -p 8545:8545 -p 8551:8551 -it pk910/ephemery-reth --datadir=/data --http --http.addr=0.0.0.0 --http.port=8545 --authrpc.addr=0.0.0.0 --authrpc.port=8551 --authrpc.vhosts=* --authrpc.jwtsecret=/execution-auth.jwt
 ```
 
+**EthereumJS**:
+```
+docker run -v $(pwd)/jwtsecret:/execution-auth.jwt:ro --network host -e JWT_SECRET=/execution-auth.jwt -it pk910/ephemery-ethereumjs
+```
+
 ### Consensus Clients
 
 **Lighthouse**:

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker run --pull always -v $(pwd)/jwtsecret:/execution-auth.jwt:ro -v $(pwd)/el
 
 **EthereumJS**:
 ```
-docker run -v $(pwd)/jwtsecret:/execution-auth.jwt:ro --network host -e JWT_SECRET=/execution-auth.jwt -it pk910/ephemery-ethereumjs
+docker run -v $(pwd)/jwtsecret:/execution-auth.jwt:ro -v $(pwd)/el:/.ethereum --network host -e JWT_SECRET=/execution-auth.jwt -it pk910/ephemery-ethereumjs
 ```
 
 ### Consensus Clients

--- a/clients/ethereumjs/Dockerfile
+++ b/clients/ethereumjs/Dockerfile
@@ -1,14 +1,10 @@
 FROM ethpandaops/ethereumjs:master
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  curl \
-  bash \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl bash && rm -rf /var/cache/apk/*
 RUN mkdir /ephemery_config && chmod 777 /ephemery_config
 
 RUN mkdir /wrapper
 COPY ../../wrapper/wrapper.lib.sh clients/ethereumjs/wrapper.sh /wrapper/
 
 EXPOSE 8545 8551 30303
-ENTRYPOINT ["wrapper.sh"]
+ENTRYPOINT ["/wrapper/wrapper.sh"]

--- a/clients/ethereumjs/Dockerfile
+++ b/clients/ethereumjs/Dockerfile
@@ -1,0 +1,14 @@
+FROM ethpandaops/ethereumjs:master
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  curl \
+  bash \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+RUN mkdir /ephemery_config && chmod 777 /ephemery_config
+
+RUN mkdir /wrapper
+COPY ../../wrapper/wrapper.lib.sh clients/ethereumjs/wrapper.sh /wrapper/
+
+EXPOSE 8545 8551 30303
+ENTRYPOINT ["wrapper.sh"]

--- a/clients/ethereumjs/wrapper.sh
+++ b/clients/ethereumjs/wrapper.sh
@@ -26,7 +26,7 @@ start_client() {
     fi
 
     echo "args: ${client_args[@]} $ephemery_args"
-    node /usr/app/packages/client/dist/esm/bin/cli.js  --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --jwtSecret=$JWT_SECRET "${client_args[@]}" $ephemery_args
+    node /usr/app/packages/client/dist/esm/bin/cli.js  --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAddr 0.0.0.0 --jwtSecret=/execution-auth.jwt "${client_args[@]}" $ephemery_args
 }
 
 reset_client() {
@@ -34,7 +34,7 @@ reset_client() {
         echo "[EphemeryWrapper] clearing ethjs data"
     fi
 
-    node /usr/app/packages/client/dist/esm/bin/cli.js --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --jwtSecret=$JWT_SECRET
+    node /usr/app/packages/client/dist/esm/bin/cli.js --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAddr 0.0.0.0 --jwtSecret=/execution-auth.jwt
 }
 
-ephemery_wrapper "geth" "$client_datadir" "reset_client" "start_client"
+ephemery_wrapper "$client_datadir" "reset_client" "start_client"

--- a/clients/ethereumjs/wrapper.sh
+++ b/clients/ethereumjs/wrapper.sh
@@ -24,9 +24,15 @@ start_client() {
     if [ -z "$(echo "${client_args[@]}" | grep "bootnodes")" ]; then
         ephemery_args="$ephemery_args --bootnodes=$BOOTNODE_ENODE_LIST"
     fi
+    if [ -z "$(echo "${client_args[@]}" | grep "gethGenesis")" ]; then
+        ephemery_args="$ephemery_args --gethGenesis=$testnet_dir/genesis.json"
+    fi
+    if [ -z "$(echo "${client_args[@]}" | grep "jwtSecret")" ]; then
+        ephemery_args="$ephemery_args --jwtSecret=/execution-auth.jwt"
+    fi
 
     echo "args: ${client_args[@]} $ephemery_args"
-    node /usr/app/packages/client/dist/esm/bin/cli.js  --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAddr 0.0.0.0 --jwtSecret=/execution-auth.jwt "${client_args[@]}" $ephemery_args
+    node /usr/app/packages/client/dist/esm/bin/cli.js  "${client_args[@]}" $ephemery_args
 }
 
 reset_client() {

--- a/clients/ethereumjs/wrapper.sh
+++ b/clients/ethereumjs/wrapper.sh
@@ -26,7 +26,7 @@ start_client() {
     fi
 
     echo "args: ${client_args[@]} $ephemery_args"
-    node /usr/app/packages/client/dist/esm/bin/cli.js  --datadir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAuth=false "${client_args[@]}" $ephemery_args
+    node /usr/app/packages/client/dist/esm/bin/cli.js  --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --jwtSecret=$JWT_SECRET "${client_args[@]}" $ephemery_args
 }
 
 reset_client() {
@@ -34,7 +34,7 @@ reset_client() {
         echo "[EphemeryWrapper] clearing ethjs data"
     fi
 
-    node /usr/app/packages/client/dist/esm/bin/cli.js --datadir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAuth=false
+    node /usr/app/packages/client/dist/esm/bin/cli.js --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --jwtSecret=$JWT_SECRET
 }
 
 ephemery_wrapper "geth" "$client_datadir" "reset_client" "start_client"

--- a/clients/ethereumjs/wrapper.sh
+++ b/clients/ethereumjs/wrapper.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+client_datadir="~/.ethereum"
+
+client_args=("$@")
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --datadir=*)
+        client_datadir="${1#*=}"
+        ;;
+    --datadir)
+        client_datadir="${2}"
+        ;;
+    esac
+    shift
+done
+
+source /wrapper/wrapper.lib.sh
+
+start_client() {
+    source $testnet_dir/nodevars_env.txt
+
+    ephemery_args=""
+    if [ -z "$(echo "${client_args[@]}" | grep "bootnodes")" ]; then
+        ephemery_args="$ephemery_args --bootnodes=$BOOTNODE_ENODE_LIST"
+    fi
+
+    echo "args: ${client_args[@]} $ephemery_args"
+    node /usr/app/packages/client/dist/esm/bin/cli.js  --datadir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAuth=false "${client_args[@]}" $ephemery_args
+}
+
+reset_client() {
+    if [ -d $client_datadir ]; then
+        echo "[EphemeryWrapper] clearing ethjs data"
+    fi
+
+    node /usr/app/packages/client/dist/esm/bin/cli.js --datadir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAuth=false
+}
+
+ephemery_wrapper "geth" "$client_datadir" "reset_client" "start_client"

--- a/clients/ethereumjs/wrapper.sh
+++ b/clients/ethereumjs/wrapper.sh
@@ -5,10 +5,10 @@ client_datadir="~/.ethereum"
 client_args=("$@")
 while [[ $# -gt 0 ]]; do
     case $1 in
-    --datadir=*)
+    --dataDir=*)
         client_datadir="${1#*=}"
         ;;
-    --datadir)
+    --dataDir)
         client_datadir="${2}"
         ;;
     esac
@@ -34,7 +34,7 @@ reset_client() {
         echo "[EphemeryWrapper] clearing ethjs data"
     fi
 
-    node /usr/app/packages/client/dist/esm/bin/cli.js --dataDir=$client_datadir --gethGenesis=$testnet_dir/genesis.json --rpcEngine --rpcEngineAddr 0.0.0.0 --jwtSecret=/execution-auth.jwt
+    rm -rf $client_datadir
 }
 
-ephemery_wrapper "$client_datadir" "reset_client" "start_client"
+ephemery_wrapper node "$client_datadir" "reset_client" "start_client"


### PR DESCRIPTION
Adds a docker recipe for the `ethereumjs` client that supports the `ephemery-client-wrapper`. Still ironing out the bugs on how to get the correct ports exposed so the ethjs client is reachable but the client starts up with what appears to be the correct ephemery configuration